### PR TITLE
Add hook implementation

### DIFF
--- a/crates/brace-hook/Cargo.toml
+++ b/crates/brace-hook/Cargo.toml
@@ -6,3 +6,6 @@ description = "Hook discovery for dynamic codebases."
 repository = "https://github.com/brace-rs/brace-hook"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+
+[dev-dependencies]
+paste = "0.1"

--- a/crates/brace-hook/src/lib.rs
+++ b/crates/brace-hook/src/lib.rs
@@ -1,13 +1,92 @@
-pub fn add_two(a: i32) -> i32 {
-    a + 2
+use std::borrow::Borrow;
+
+pub fn invoke<'a, T, B, A>(hook: B, args: A) -> T::Output
+where
+    T: Hook<A>,
+    B: Borrow<T>,
+{
+    Hook::invoke(hook.borrow(), args)
 }
+
+pub trait Hook<A> {
+    type Output;
+
+    fn invoke(&self, args: A) -> Self::Output;
+}
+
+impl<T, O> Hook<()> for T
+where
+    T: Fn() -> O,
+{
+    type Output = O;
+
+    fn invoke(&self, _: ()) -> O {
+        (self)()
+    }
+}
+
+macro_rules! peel {
+    ($name:ident, $($other:ident,)*) => (tuple! { $($other,)* })
+}
+
+macro_rules! tuple {
+    () => ();
+    ( $($name:ident,)+ ) => {
+        impl<Func, Out, $($name,)+> Hook<($($name,)+)> for Func
+        where
+            Func: Fn($($name,)+) -> Out,
+        {
+            type Output = Out;
+
+            #[allow(non_snake_case)]
+            fn invoke(&self, args: ($($name,)+)) -> Self::Output {
+                let ($($name,)+) = args;
+
+                (self)($($name,)+)
+            }
+        }
+
+        peel! { $($name,)+ }
+    };
+}
+
+tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{invoke, Hook};
+
+    fn my_hook(a: &str, b: &str) -> String {
+        format!("my_hook ({}, {})", a, b)
+    }
 
     #[test]
-    fn it_adds_two() {
-        assert_eq!(add_two(2), 4);
+    fn test_hook_invoke() {
+        assert_eq!(
+            invoke(my_hook, ("hello", "world")),
+            String::from("my_hook (hello, world)")
+        );
+        assert_eq!(
+            my_hook.invoke(("hello", "world")),
+            String::from("my_hook (hello, world)")
+        );
     }
+
+    macro_rules! tuple {
+        () => ();
+        ( $name:ident, $($rest:ident,)* ) => {
+            paste::item! {
+                fn [<my_hook $name>]($($rest: &'static str,)*) {}
+
+                #[test]
+                fn [<test_hook_args $name>]() {
+                    [<my_hook $name>].invoke(($(stringify!($rest),)*))
+                }
+            }
+
+            tuple! { $($rest,)* }
+        };
+    }
+
+    tuple! { _11, _10, _9, _8, _7, _6, _5, _4, _3, _2, _1, _0, }
 }

--- a/crates/brace-hook/src/lib.rs
+++ b/crates/brace-hook/src/lib.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-pub fn invoke<'a, T, B, A>(hook: B, args: A) -> T::Output
+pub fn invoke<T, B, A>(hook: B, args: A) -> T::Output
 where
     T: Hook<A>,
     B: Borrow<T>,


### PR DESCRIPTION
This adds the initial implementation of the `Hook` trait and the `invoke` method. The `Hook` trait is implemented on functions and mimics the unstable function traits of core. This allows a hook to be called with up to twelve arguments in a tuple.