### PR TITLE
Update continuous integration workflow lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lint:
     name: Lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -28,7 +29,7 @@ jobs:
         args: --all -- --check
 
     - name: Clippy
-      uses: actions-rs/clippy-check@v1
+      uses: brace-rs/clippy-check@b75a09651cc90c3921c41888815fe6a7a0b0adae
       with:
         args: --all -- -D warnings
         name: Lint / Results
@@ -37,7 +38,6 @@ jobs:
   build:
     name: Build / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: lint
     strategy:
       matrix:
         target:
@@ -103,7 +103,6 @@ jobs:
   test:
     name: Test / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: lint
     strategy:
       matrix:
         target:
@@ -169,7 +168,6 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: lint
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This updates the continuous integration lint job to only run on pull requests and to use a custom clippy action until the unnamed workflow issue is fixed.