### PR TITLE
Fix clippy too many arguments lint

### DIFF
--- a/crates/brace-hook/src/lib.rs
+++ b/crates/brace-hook/src/lib.rs
@@ -76,6 +76,7 @@ mod tests {
         () => ();
         ( $name:ident, $($rest:ident,)* ) => {
             paste::item! {
+                #[allow(clippy::too_many_arguments)]
                 fn [<my_hook $name>]($($rest: &'static str,)*) {}
 
                 #[test]


### PR DESCRIPTION
This fixes the too many arguments clippy lint in the generated test code. This does not appear under regular linting performed by continuous integration as it does not cover tests.

The issue shows up due to local IDE changes that now runs clippy on all targets on save. The change was made because of an issue where clippy will not actually run when using the Rust Analyzer extension in Visual Studio Code because it runs the cargo check command. This caused some linting errors in various projects to go by unnoticed until the CI workflow picked them up.