### PR TITLE
Add procedural attribute macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: latest
-        args: --ignore-tests
+        args: --ignore-tests --exclude-files crates/brace-hook-macros
 
     - name: Upload code coverage
       uses: codecov/codecov-action@v1

--- a/crates/brace-hook-macros/Cargo.toml
+++ b/crates/brace-hook-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "brace-hook-macros"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "Procedural macros for hook discovery."
+repository = "https://github.com/brace-rs/brace-hook"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"

--- a/crates/brace-hook-macros/src/lib.rs
+++ b/crates/brace-hook-macros/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};

--- a/crates/brace-hook-macros/src/lib.rs
+++ b/crates/brace-hook-macros/src/lib.rs
@@ -1,0 +1,60 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream, Result};
+use syn::{parse_macro_input, Error, ItemFn, LitStr, Token};
+
+mod kw {
+    syn::custom_keyword!(name);
+}
+
+struct Args {
+    pub name: Option<LitStr>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> Result<Self> {
+        if input.is_empty() {
+            return Ok(Args { name: None });
+        }
+
+        input.parse::<kw::name>()?;
+        input.parse::<Token![=]>()?;
+
+        let name: LitStr = input.parse()?;
+
+        Ok(Args { name: Some(name) })
+    }
+}
+
+fn fn_name(input: ItemFn) -> Option<String> {
+    Some(input.sig.ident.to_string())
+}
+
+#[proc_macro_attribute]
+pub fn hook(args: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemFn);
+    let method = input.sig.ident.clone();
+
+    let args = parse_macro_input!(args as Args);
+    let name = match args.name {
+        Some(name) => quote!(#name),
+        None => match fn_name(input.clone()) {
+            Some(name) => quote!(#name),
+            None => {
+                let msg = "use #[brace_hook::hook(name = \"...\")] to specify a name";
+
+                return TokenStream::from(
+                    Error::new_spanned(&input.sig.ident, msg).to_compile_error(),
+                );
+            }
+        },
+    };
+
+    TokenStream::from(quote! {
+        #input
+
+        brace_hook::register! { #name, #method }
+    })
+}

--- a/crates/brace-hook/Cargo.toml
+++ b/crates/brace-hook/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+brace-hook-macros = { path = "../brace-hook-macros" }
 dyn-clone = "1.0"
 inventory = "0.1"
 once_cell = "1.4"

--- a/crates/brace-hook/src/lib.rs
+++ b/crates/brace-hook/src/lib.rs
@@ -4,6 +4,7 @@ use dyn_clone::DynClone;
 
 use self::registry::REGISTRY;
 
+pub use brace_hook_macros::hook;
 pub use inventory;
 
 pub use self::error::Error;

--- a/crates/brace-hook/tests/integration.rs
+++ b/crates/brace-hook/tests/integration.rs
@@ -1,5 +1,11 @@
-use brace_hook::{invoke_all, register};
+use brace_hook::{hook, invoke_all, register};
 
+#[hook]
+fn my_hook(input: &str) -> String {
+    format!("zero: {}", input)
+}
+
+#[hook(name = "my_hook")]
 fn hook_1(input: &str) -> String {
     format!("one: {}", input)
 }
@@ -8,15 +14,15 @@ fn hook_2(input: &str) -> String {
     format!("two: {}", input)
 }
 
-register!("hook", hook_1);
-register!("hook", hook_2);
+register!("my_hook", hook_2);
 
 #[test]
 fn test_static_discovery() {
-    let res: Vec<String> = invoke_all("hook", ("hello",)).unwrap();
+    let res: Vec<String> = invoke_all("my_hook", ("hello",)).unwrap();
 
-    assert_eq!(res.len(), 2);
+    assert_eq!(res.len(), 3);
 
+    assert!(res.contains(&String::from("zero: hello")));
     assert!(res.contains(&String::from("one: hello")));
     assert!(res.contains(&String::from("two: hello")));
 }


### PR DESCRIPTION
This adds a custom `hook` attribute macro using the procedural macros API to allow tagging a function to register a hook instead of having to manually call the register macro.