### PR TITLE
Fix unused variables warning on default hooks

### DIFF
--- a/crates/brace-hook-macros/src/declaration.rs
+++ b/crates/brace-hook-macros/src/declaration.rs
@@ -43,6 +43,7 @@ pub fn expand(mut input: HookFnSignature) -> TokenStream {
 
     let default = match input.block {
         Some(block) => quote! {
+            #[allow(unused_variables)]
             fn default(#args) -> #ret #block
         },
         None => quote!(),


### PR DESCRIPTION
This fixes the unused variables warning for a default hook implementation. The default implementation does not need to use all variables but the names are required for the macro to work.