### PR TITLE
Fix crate path rename attribute

### DIFF
--- a/crates/brace-hook-macros/src/attr.rs
+++ b/crates/brace-hook-macros/src/attr.rs
@@ -1,7 +1,8 @@
 use syn::parse::{Error, ParseStream, Result};
 use syn::{parse_quote, Attribute, Path, Token};
 
-// #[hook_attr(crate = path::to::brace_hook)]
+// #[hook_attr(crate = brace_hook_crate)]
+// See https://github.com/dtolnay/inventory/issues/10
 pub fn crate_path(attrs: &mut Vec<Attribute>) -> Result<Path> {
     let mut path = None;
     let mut errors: Option<Error> = None;

--- a/crates/brace-hook-macros/src/registration.rs
+++ b/crates/brace-hook-macros/src/registration.rs
@@ -12,6 +12,9 @@ pub fn expand(path: Path, weight: LitInt, mut input: ItemFn) -> TokenStream {
     quote::quote! {
         #input
 
-        #krate::register!(#path, #name, #weight);
+        #krate::inventory::submit! {
+            #![crate = #krate]
+            #path::new(#name, #weight)
+        }
     }
 }

--- a/crates/brace-hook/tests/integration.rs
+++ b/crates/brace-hook/tests/integration.rs
@@ -116,17 +116,15 @@ fn test_hook_with_mutations() {
 }
 
 mod custom {
-    pub mod path {
-        pub use brace_hook::*;
-    }
+    pub use brace_hook::*;
 }
 
 #[hook]
-#[hook_attr(crate = custom::path)]
+#[hook_attr(crate = custom)]
 fn relocate() {}
 
 #[hook(relocate, 1)]
-#[hook_attr(crate = custom::path)]
+#[hook_attr(crate = custom)]
 fn relocated() {}
 
 #[test]


### PR DESCRIPTION
This is a semi-fix for the crate path renaming attribute where the path was not properly passed to the register macro. The limitation now is that the new name must be an identifier instead of a path as the `inventory` crate does not yet accept paths.