### PR TITLE
Add new default hook handling mechanism

### DIFF
--- a/crates/brace-hook-macros/src/registration.rs
+++ b/crates/brace-hook-macros/src/registration.rs
@@ -14,7 +14,7 @@ pub fn expand(path: Path, weight: LitInt, mut input: ItemFn) -> TokenStream {
 
         #krate::inventory::submit! {
             #![crate = #krate]
-            #path::new(#name, #weight)
+            #path::new(#name, #weight, false)
         }
     }
 }

--- a/crates/brace-hook/src/macros.rs
+++ b/crates/brace-hook/src/macros.rs
@@ -3,14 +3,21 @@ macro_rules! register {
     ($type:path, $hook:path) => {
         $crate::inventory::submit! {
             #![crate = $crate]
-            $type::new($hook, 0)
+            $type::new($hook, 0, false)
         }
     };
 
     ($type:path, $hook:path, $weight:expr) => {
         $crate::inventory::submit! {
             #![crate = $crate]
-            $type::new($hook, $weight)
+            $type::new($hook, $weight, false)
+        }
+    };
+
+    ($type:path, $hook:path, $weight:expr, $default:expr) => {
+        $crate::inventory::submit! {
+            #![crate = $crate]
+            $type::new($hook, $weight, $default)
         }
     };
 }


### PR DESCRIPTION
This adds a new default hook handling mechanism where the default hook is registered as if it were another hook implementation instead of being a special case. This allows the register macro to enable the creation of additional defaults.