### PR TITLE
Add custom inventory collect implementation

### DIFF
--- a/crates/brace-hook-macros/src/declaration.rs
+++ b/crates/brace-hook-macros/src/declaration.rs
@@ -75,7 +75,13 @@ pub fn expand(mut input: HookFnSignature) -> TokenStream {
             }
         }
 
-        #krate::inventory::collect!(#name);
+        impl #krate::inventory::Collect for #name {
+            #[inline]
+            fn registry() -> &'static #krate::inventory::Registry<Self> {
+                static REGISTRY: #krate::inventory::Registry<#name> = #krate::inventory::Registry::new();
+                &REGISTRY
+            }
+        }
 
         #default
     }

--- a/crates/brace-hook/Cargo.toml
+++ b/crates/brace-hook/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 
 [dependencies]
 brace-hook-macros = { path = "../brace-hook-macros" }
-inventory = "0.1"
+inventory = "0.1.7"


### PR DESCRIPTION
This adds a custom `Collect` trait implementation instead of relying on the collect macro from the inventory crate. This should further support renaming the crate as the macro expansion required the inventory crate to be present. The minimum version has been bumped to ensure the collect API is exported.