### PR TITLE
Add invoke lifetimes expansion

### DIFF
--- a/crates/brace-hook-macros/Cargo.toml
+++ b/crates/brace-hook-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["visit-mut"] }

--- a/crates/brace-hook-macros/src/declaration.rs
+++ b/crates/brace-hook-macros/src/declaration.rs
@@ -19,6 +19,16 @@ pub fn expand(mut input: HookFnSignature) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
+    let lifetimes = match input.lifetimes() {
+        Ok(res) => res,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let args_lifetimes = match input.args_lifetimes() {
+        Ok(res) => res,
+        Err(err) => return err.to_compile_error(),
+    };
+
     let ret = input.returns();
     let vis = input.vis;
     let args = input.inputs;
@@ -51,7 +61,7 @@ pub fn expand(mut input: HookFnSignature) -> TokenStream {
                 Self(Box::new(hook), weight, default)
             }
 
-            pub fn invoke(#args) -> Vec<#ret> {
+            pub fn invoke #lifetimes (#args_lifetimes) -> Vec<#ret> {
                 let mut out = Vec::new();
                 let mut hooks: Vec<&'static #name> = #krate::inventory::iter::<#name>
                     .into_iter()

--- a/crates/brace-hook-macros/src/lib.rs
+++ b/crates/brace-hook-macros/src/lib.rs
@@ -6,6 +6,7 @@ use self::args::Args;
 mod args;
 mod attr;
 mod declaration;
+mod lifetime;
 mod registration;
 mod signature;
 

--- a/crates/brace-hook-macros/src/lifetime.rs
+++ b/crates/brace-hook-macros/src/lifetime.rs
@@ -1,0 +1,90 @@
+use std::iter::FromIterator;
+
+use proc_macro2::Span;
+use syn::punctuated::Punctuated;
+use syn::token::{Gt, Lt};
+use syn::visit_mut::{self, VisitMut};
+use syn::{
+    GenericArgument, GenericParam, Generics, Lifetime, LifetimeDef, Receiver, TypeReference,
+};
+
+pub struct Lifetimes {
+    pub elided: Vec<Lifetime>,
+    pub explicit: Vec<Lifetime>,
+    pub name: &'static str,
+}
+
+impl Lifetimes {
+    pub fn new(name: &'static str) -> Self {
+        Lifetimes {
+            elided: Vec::new(),
+            explicit: Vec::new(),
+            name,
+        }
+    }
+
+    pub fn generics(&self) -> Generics {
+        Generics {
+            lt_token: Some(Lt::default()),
+            params: Punctuated::from_iter(
+                self.explicit
+                    .iter()
+                    .chain(&self.elided)
+                    .filter(|lifetime| lifetime.ident != "static")
+                    .map(|lifetime| {
+                        GenericParam::Lifetime(LifetimeDef {
+                            attrs: Vec::new(),
+                            lifetime: lifetime.clone(),
+                            colon_token: None,
+                            bounds: Punctuated::new(),
+                        })
+                    }),
+            ),
+            gt_token: Some(Gt::default()),
+            where_clause: None,
+        }
+    }
+
+    fn visit_opt_lifetime(&mut self, lifetime: &mut Option<Lifetime>) {
+        match lifetime {
+            None => *lifetime = Some(self.next_lifetime()),
+            Some(lifetime) => self.visit_lifetime(lifetime),
+        }
+    }
+
+    fn visit_lifetime(&mut self, lifetime: &mut Lifetime) {
+        if lifetime.ident == "_" {
+            *lifetime = self.next_lifetime();
+        } else {
+            self.explicit.push(lifetime.clone());
+        }
+    }
+
+    fn next_lifetime(&mut self) -> Lifetime {
+        let name = format!("{}{}", self.name, self.elided.len());
+        let life = Lifetime::new(&name, Span::call_site());
+        self.elided.push(life.clone());
+        life
+    }
+}
+
+impl VisitMut for Lifetimes {
+    fn visit_receiver_mut(&mut self, arg: &mut Receiver) {
+        if let Some((_, lifetime)) = &mut arg.reference {
+            self.visit_opt_lifetime(lifetime);
+        }
+    }
+
+    fn visit_type_reference_mut(&mut self, ty: &mut TypeReference) {
+        self.visit_opt_lifetime(&mut ty.lifetime);
+        visit_mut::visit_type_reference_mut(self, ty);
+    }
+
+    fn visit_generic_argument_mut(&mut self, gen: &mut GenericArgument) {
+        if let GenericArgument::Lifetime(lifetime) = gen {
+            self.visit_lifetime(lifetime);
+        }
+
+        visit_mut::visit_generic_argument_mut(self, gen);
+    }
+}


### PR DESCRIPTION
This adds lifetimes expansion to the invoke method. This does not offer much other than being the first step to returning an iterator.